### PR TITLE
Moved <mutex> include from PacketLog.cpp to .h as it was causing a co…

### DIFF
--- a/src/server/game/Server/Protocol/PacketLog.cpp
+++ b/src/server/game/Server/Protocol/PacketLog.cpp
@@ -24,7 +24,6 @@
 #include "WorldPacket.h"
 
 #include <thread>
-#include <mutex>
 
  // Packet logging structures in PKT 3.1 format
 struct LogHeader

--- a/src/server/game/Server/Protocol/PacketLog.h
+++ b/src/server/game/Server/Protocol/PacketLog.h
@@ -21,6 +21,7 @@
 
 #include "Common.h"
 #include <ace/Singleton.h>
+#include <mutex>
 
 enum Direction
 {


### PR DESCRIPTION
Moved <mutex> include from PacketLog.cpp to .h as it was causing a compile error on some windows system.