### PR TITLE
Remove _BUILD_DIRECTIVE from GitRevision.cpp

### DIFF
--- a/src/server/shared/GitRevision.cpp
+++ b/src/server/shared/GitRevision.cpp
@@ -87,7 +87,7 @@ char const* GitRevision::GetFullDatabase()
 char const* GitRevision::GetFullVersion()
 {
   return "ArkCore4-NG rev. " VER_PRODUCTVERSION_STR
-    " (" TRINITY_PLATFORM_STR ", " _BUILD_DIRECTIVE ", " TRINITY_LINKAGE_TYPE_STR ")";
+    " (" TRINITY_PLATFORM_STR ", " ", " TRINITY_LINKAGE_TYPE_STR ")";
 }
 
 char const* GitRevision::GetCompanyNameStr()


### PR DESCRIPTION
The reference to the variable is temporarily removed because it produced a warning when compiling in linux.

- Tested on Debian 10